### PR TITLE
Custom Prompt and Nested Tag Support (Resolves #22)

### DIFF
--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -12,6 +12,7 @@ export interface AITaggerSettings {
     cloudModel: string;
     cloudServiceType: AdapterType;
     taggingMode: TaggingMode;
+    customPrompt: string;
     excludedFolders: string[];
     language: LanguageCode;
     predefinedTagsPath: string;
@@ -33,6 +34,7 @@ export const DEFAULT_SETTINGS: AITaggerSettings = {
     cloudModel: 'gpt-4',
     cloudServiceType: 'openai',
     taggingMode: TaggingMode.GenerateNew,
+    customPrompt: "",
     excludedFolders: [],
     language: 'default',
     predefinedTagsPath: '',

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -550,6 +550,11 @@ export abstract class BaseLLMService {
                     }
                     break;
                     
+                case TaggingMode.Custom:
+                    // For custom mode, build prompt using the custom prompt from settings
+                    // buildTagPrompt will access pluginSettings directly
+                    prompt = this.buildPrompt(content, candidateTags, mode, maxTags, language);
+                    break;
                 default:
                     // Default behavior for future or unknown modes
                     prompt = this.buildPrompt(content, candidateTags, mode, maxTags, language);
@@ -558,7 +563,7 @@ export abstract class BaseLLMService {
             if (!prompt.trim()) {
                 throw new Error('Failed to build analysis prompt');
             }
-            
+
             // Send request and get response
             const response = await this.sendRequest(prompt);
             

--- a/src/services/prompts/types.ts
+++ b/src/services/prompts/types.ts
@@ -18,5 +18,11 @@ export enum TaggingMode {
      * Combine predefined tags with newly generated ones.
      * The AI will both select from provided tags and suggest new ones.
      */
-    Hybrid = 'hybrid'
+    Hybrid = 'hybrid',
+
+    /**
+     * Use a custom prompt defined by the user.
+     * The AI will generate tags based on the custom prompt and note content.
+     */
+    Custom = 'custom'
 } 

--- a/src/ui/settings/TaggingSettingsSection.ts
+++ b/src/ui/settings/TaggingSettingsSection.ts
@@ -16,7 +16,7 @@ export class TaggingSettingsSection extends BaseSettingSection {
             const shouldShowTagSource = this.plugin.settings.taggingMode !== TaggingMode.GenerateNew;
             this.tagSourceSetting.settingEl.style.display = shouldShowTagSource ? 'flex' : 'none';
         }
-        
+
         // Determine whether to show predefined tags file setting
         if (this.predefinedTagsFileSetting) {
             const shouldShowTagsFile = this.plugin.settings.taggingMode !== TaggingMode.GenerateNew && 
@@ -35,7 +35,8 @@ export class TaggingSettingsSection extends BaseSettingSection {
                 .addOptions({
                     [TaggingMode.PredefinedTags]: 'Use predefined tags only',
                     [TaggingMode.GenerateNew]: 'Generate new tags',
-                    [TaggingMode.Hybrid]: 'Hybrid mode (Generate + Predefined)'
+                    [TaggingMode.Hybrid]: 'Hybrid mode (Generate + Predefined)',
+                    [TaggingMode.Custom]: 'Use custom prompt'
                 })
                 .setValue(this.plugin.settings.taggingMode)
                 .onChange(async (value) => {
@@ -403,5 +404,19 @@ export class TaggingSettingsSection extends BaseSettingSection {
                         await this.plugin.saveSettings();
                     });
             });
+        new Setting(this.containerEl)
+        .setName("Custom prompt")
+        .setDesc("Enter your custom prompt.")
+        .addTextArea(text => {
+            text
+            .setPlaceholder(`Example:\n Please actively use nested tags.\nTags can be nested using "/".\nFor example, you can do "AI/Gemini", "News/Politics".`)
+            .setValue(this.plugin.settings.customPrompt)
+            .onChange(async (value) => {
+                this.plugin.settings.customPrompt = value;
+                await this.plugin.saveSettings();
+            });
+            text.inputEl.rows = 8;
+            text.inputEl.cols = 50;
+        });
     }
 }

--- a/src/utils/tagUtils.ts
+++ b/src/utils/tagUtils.ts
@@ -87,7 +87,7 @@ export class TagUtils {
         
         // Replace spaces and special characters with hyphens
         formatted = formatted.replace(/\s+/g, '-'); // First replace spaces with hyphens
-        formatted = formatted.replace(/[^\p{L}\p{N}-]/gu, '-'); // Then replace other special chars
+        formatted = formatted.replace(/[^\p{L}\p{N}/-]/gu, '-'); // Then replace other special chars
         
         // Collapse multiple consecutive hyphens into a single one
         formatted = formatted.replace(/-{2,}/g, '-');


### PR DESCRIPTION
Hi,

Following up on issue #22, which I opened a couple of days ago, I've implemented the proposed custom prompt functionality in this pull request.

Key changes include:
* Added a custom mode.
* Added custom prompt configuration.
* Enabled support for nested tags using "/".

I believe this will enhance the plugin's flexibility and would appreciate it if you could take a look. Please let me know if you have any feedback or require further changes.

Thanks!
