### PR TITLE
Replace graph icon with network icon (lucide has no graph icon)

### DIFF
--- a/src/commands/utilityCommands.ts
+++ b/src/commands/utilityCommands.ts
@@ -16,7 +16,7 @@ export function registerUtilityCommands(plugin: AITaggerPlugin) {
     plugin.addCommand({
         id: 'show-tag-network',
         name: 'Show tag network visualization',
-        icon: 'graph',
+        icon: 'network',
         callback: async () => {
             await plugin.showTagNetwork();
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,7 +108,7 @@ export default class AITaggerPlugin extends Plugin {
         );
         
         this.addRibbonIcon(
-            'graph', 
+            'network', 
             'View tag relationships network', 
             (evt: MouseEvent) => {
                 this.showTagNetwork();

--- a/src/ui/views/TagNetworkView.ts
+++ b/src/ui/views/TagNetworkView.ts
@@ -28,7 +28,7 @@ export class TagNetworkView extends ItemView {
     }
 
     getIcon(): string {
-        return 'graph';
+        return 'network';
     }
 
     async onOpen(): Promise<void> {


### PR DESCRIPTION
## Motivation
The lucide icon set used in obsidian does not provide a "graph" icon. To maintain visual consistency and avoid missing icons, I replaced all usages of the "graph" icon with the "network" icon.

## Changes
- Replaced all references to the "graph" icon with "network" icon in the codebase.
- Updated related UI components to use the new icon.

## Impact
- No breaking changes.
- The UI now displays the "network" icon instead of the missing "graph" icon.

If you have any suggestions for a better replacement icon, please let me know!