### PR TITLE
Fix file exclusion and markdown file retrieval

### DIFF
--- a/src/commands/clearCommands.ts
+++ b/src/commands/clearCommands.ts
@@ -29,12 +29,13 @@ export function registerClearCommands(plugin: AITaggerPlugin) {
                 return;
             }
 
-            const parentPath = activeFile.parent?.path ?? "";
-            const allFiles = plugin.app.vault.getMarkdownFiles();
-            const filesInFolder = allFiles.filter(file => {
-                const filePath = file.parent?.path ?? "";
-                return filePath === parentPath;
-            });
+            const parentFolder = activeFile.parent;
+            if (!parentFolder) {
+                new Notice('No parent folder found');
+                return;
+            }
+
+            const filesInFolder = plugin.getNonExcludedMarkdownFilesFromFolder(parentFolder);
 
             if (filesInFolder.length === 0) {
                 new Notice('No markdown files found in current folder');

--- a/src/commands/generateCommands.ts
+++ b/src/commands/generateCommands.ts
@@ -77,8 +77,7 @@ export function registerGenerateCommands(plugin: AITaggerPlugin) {
                 return;
             }
 
-            const filesInFolder = parentFolder.children
-                .filter((file): file is TFile => file instanceof TFile && file.extension === 'md');
+            const filesInFolder = plugin.getNonExcludedMarkdownFilesFromFolder(parentFolder);
 
             if (filesInFolder.length === 0) {
                 new Notice('No md files');
@@ -104,7 +103,7 @@ export function registerGenerateCommands(plugin: AITaggerPlugin) {
         name: 'Generate tags for vault',
         icon: 'tag',
         callback: async () => {
-            const files = plugin.app.vault.getMarkdownFiles();
+            const files = plugin.getNonExcludedMarkdownFiles();
             if (files.length === 0) {
                 new Notice('No md files');
                 return;

--- a/src/commands/predefinedTagsCommands.ts
+++ b/src/commands/predefinedTagsCommands.ts
@@ -73,8 +73,7 @@ export function registerPredefinedTagsCommands(plugin: AITaggerPlugin) {
                 return;
             }
 
-            const filesInFolder = parentFolder.children
-                .filter((file): file is TFile => file instanceof TFile && file.extension === 'md');
+            const filesInFolder = plugin.getNonExcludedMarkdownFilesFromFolder(parentFolder);
 
             if (filesInFolder.length === 0) {
                 new Notice('No md files');
@@ -148,7 +147,7 @@ export function registerPredefinedTagsCommands(plugin: AITaggerPlugin) {
                 return;
             }
 
-            const files = plugin.app.vault.getMarkdownFiles();
+            const files = plugin.getNonExcludedMarkdownFiles();
             if (files.length === 0) {
                 new Notice('No md files');
                 return;

--- a/src/utils/tagNetworkUtils.ts
+++ b/src/utils/tagNetworkUtils.ts
@@ -34,9 +34,9 @@ export class TagNetworkManager {
         this.app = app;
     }
 
-    async buildTagNetwork(): Promise<Map<string, TagData>> {
+    async buildTagNetwork(files?: TFile[]): Promise<Map<string, TagData>> {
         this.tagData.clear();
-        const allFiles = this.app.vault.getMarkdownFiles();
+        const allFiles = files || this.app.vault.getMarkdownFiles();
         
         for (const file of allFiles) {
             const cache = this.app.metadataCache.getFileCache(file);

--- a/src/utils/tagOperations.ts
+++ b/src/utils/tagOperations.ts
@@ -57,14 +57,6 @@ export class TagOperations {
     }
 
     /**
-     * Clear tags from all notes in the vault
-     */
-    public async clearVaultTags(): Promise<BatchProcessResult> {
-        const files = this.app.vault.getMarkdownFiles();
-        return this.clearDirectoryTags(files);
-    }
-
-    /**
      * Cancel any ongoing batch operations
      */
     public cancelOperations(): void {

--- a/src/utils/tagUtils.ts
+++ b/src/utils/tagUtils.ts
@@ -630,8 +630,8 @@ export class TagUtils {
                     return true;
                 }
                 
-                // Simple substring match
-                if (filePath.toLowerCase().includes(pattern.toLowerCase())) {
+                // Path pattern matching - use startsWith for precise matching
+                if (filePath.toLowerCase().startsWith(pattern.toLowerCase())) {
                     return true;
                 }
                 
@@ -654,6 +654,52 @@ export class TagUtils {
         }
         
         return false;
+    }
+
+    /**
+     * Gets all markdown files from a folder recursively, including nested files
+     * @param folder - The folder to search in
+     * @returns Array of TFile objects that are markdown files
+     */
+    private static getMarkdownFilesFromFolder(folder: TFolder): TFile[] {
+        const markdownFiles: TFile[] = [];
+        
+        for (const child of folder.children) {
+            if (child instanceof TFile && child.extension === 'md') {
+                markdownFiles.push(child);
+            } else if (child instanceof TFolder) {
+                // Recursively get files from subfolders
+                markdownFiles.push(...this.getMarkdownFilesFromFolder(child));
+            }
+        }
+        
+        return markdownFiles;
+    }
+
+    /**
+     * Gets non-excluded markdown files from vault or specific folder
+     * @param app - Obsidian App instance
+     * @param excludePatterns - Array of exclusion patterns
+     * @param folder - Optional folder to limit search to (includes nested files)
+     * @returns Array of TFile objects that are markdown files and not excluded
+     */
+    static getNonExcludedMarkdownFiles(
+        app: App, 
+        excludePatterns: string[] = [], 
+        folder?: TFolder
+    ): TFile[] {
+        let allFiles: TFile[];
+        
+        if (folder) {
+            // Get all markdown files from the specified folder (including nested)
+            allFiles = this.getMarkdownFilesFromFolder(folder);
+        } else {
+            // Get all markdown files from the vault
+            allFiles = app.vault.getMarkdownFiles();
+        }
+        
+        // Filter out excluded files
+        return allFiles.filter(file => !this.isFileExcluded(file, excludePatterns));
     }
     
     /**


### PR DESCRIPTION
## Summary
- Fix file exclusion pattern matching to use precise startsWith matching instead of imprecise contains matching
- Add recursive markdown file retrieval from nested folders
- Centralize file filtering logic with new getNonExcludedMarkdownFiles method
- **Fix issue where file exclusion logic was not being applied previously** - excluded files were still being processed
- Improve performance and accuracy of file filtering across all plugin operations

## Test plan
- [ ] Verify excluded files are properly filtered using startsWith matching
- [ ] Test recursive file retrieval from nested folders
- [ ] Confirm tag operations work correctly with filtered file lists
- [ ] Validate that previously excluded files are now actually excluded from processing
- [ ] Validate performance improvements in file filtering

🤖 Generated with [Claude Code](https://claude.ai/code)