### PR TITLE
fix(commands): read predefined tags file in generate-tags-for-current-note (#63)

### DIFF
--- a/src/commands/generateCommands.ts
+++ b/src/commands/generateCommands.ts
@@ -1,7 +1,5 @@
 import { Editor, MarkdownFileInfo, MarkdownView, Menu, Notice, TFile } from 'obsidian';
 import type AITaggerPlugin from '../main';
-import { TagUtils } from '../utils/tagUtils';
-import { TaggingMode } from '../services/prompts/types';
 
 export function registerGenerateCommands(plugin: AITaggerPlugin) {
     // Command to generate tags for current note (with selection support)
@@ -27,29 +25,13 @@ export function registerGenerateCommands(plugin: AITaggerPlugin) {
                 return;
             }
 
-            const existingTags = TagUtils.getAllTags(plugin.app);
             new Notice(plugin.t.messages.analyzing);
 
             try {
-                let maxTags = plugin.settings.tagRangeGenerateMax;
-                if (plugin.settings.taggingMode === TaggingMode.PredefinedTags) {
-                    maxTags = plugin.settings.tagRangePredefinedMax;
-                } else if (plugin.settings.taggingMode === TaggingMode.Hybrid) {
-                    maxTags = plugin.settings.tagRangePredefinedMax + plugin.settings.tagRangeGenerateMax;
-                }
-
-                const analysis = await plugin.llmService.analyzeTags(
-                    content,
-                    existingTags,
-                    plugin.settings.taggingMode,
-                    maxTags,
-                    plugin.settings.language
-                );
-
-                const suggestedTags = analysis.suggestedTags;
-                const matchedTags = analysis.matchedExistingTags || [];
-
-                const result = await TagUtils.updateNoteTags(plugin.app, targetFile, suggestedTags, matchedTags, true, plugin.settings.replaceTags, plugin.settings.tagFormat);
+                // Route through the unified method so every tagging mode is
+                // handled consistently — in particular reading predefined tags
+                // from the configured file/vault source (issue #63).
+                const result = await plugin.analyzeAndTagNote(targetFile, content);
 
                 if (selectedText && result.success) {
                     editor.replaceSelection(selectedText);


### PR DESCRIPTION
## Problem

Closes #63.

The `generate-tags-for-current-note` command in `src/commands/generateCommands.ts` had its own tag-resolution logic that bypassed the unified `analyzeAndTagNote()` method. It always passed `TagUtils.getAllTags()` (vault frontmatter tags) as candidate tags and **never read the predefined-tags file** (`tagSourceType === 'file'`).

As a result, in **Predefined Tags** mode sourced from a file — when the vault has no existing frontmatter tags — the candidate list was empty, so the command immediately threw `failedToGenerateTags`. Every other entry point already routed through `analyzeAndTagNote()`, which resolves the tag source correctly per mode.

## Fix

Route the command through `plugin.analyzeAndTagNote(targetFile, content)`, the same unified method used elsewhere. This makes all four tagging modes (GenerateNew / PredefinedTags / Hybrid / Custom) behave consistently, including reading predefined tags from the configured file or vault source. Selection support and the issue #59 target-file capture are preserved.

Removed the now-unused `TagUtils` and `TaggingMode` imports.

## Testing

- `npm run build` passes (tsc + esbuild).