### PR TITLE
fix(tags): stop predefined mode emitting non-predefined / prose tags (#61)

### DIFF
--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -623,9 +623,12 @@ export abstract class BaseLLMService {
                 }
             }
             
-            // Remove duplicates, sanitize, and ensure strings
+            // Remove duplicates, sanitize, and ensure strings. Drop absurdly
+            // long entries: when a model returns prose/reasoning instead of a
+            // tag list, this text fallback would otherwise turn whole sentences
+            // into single hyphenated tags (issue #61).
             const uniqueTags = [...new Set(tags.map(tag => this.sanitizeTag(tag.toString())))]
-                .filter(tag => tag.length > 0);
+                .filter(tag => tag.length > 0 && tag.length <= 50);
 
             // console.log('Final extracted tags:', uniqueTags);
             return { tags: uniqueTags };
@@ -723,9 +726,26 @@ export abstract class BaseLLMService {
 
             // Send request and get response
             const response = await this.sendRequest(prompt);
-            
+
             // Parse response
-            return this.parseResponse(response, mode, maxTags);
+            const parsed = this.parseResponse(response, mode, maxTags);
+
+            // Predefined mode must never emit tags outside the candidate set.
+            // Weak models sometimes invent tags or echo prompt text as tags
+            // (issue #61), so deterministically intersect the matches with the
+            // candidate list and return the canonical candidate spelling.
+            if (mode === TaggingMode.PredefinedTags) {
+                const normalize = (s: string) => s.toLowerCase().replace(/[\s_-]+/g, '');
+                const canonical = new Map(candidateTags.map(t => [normalize(t), t]));
+                const matched = [...new Set(
+                    (parsed.matchedExistingTags || [])
+                        .map(t => canonical.get(normalize(t)))
+                        .filter((t): t is string => t !== undefined)
+                )];
+                return { matchedExistingTags: matched, suggestedTags: [] };
+            }
+
+            return parsed;
         } catch (error) {
             // Avoid double error handling
             if (error instanceof Error && error.message.startsWith('Tag analysis failed:')) {


### PR DESCRIPTION
## Problem

Closes #61.

A user on Gemini/Gemma reported two symptoms during tagging while configured for **Predefined Tags only**:

1. **Invented tags** (`crab-claw`, `lateen`, `sail-setups-square`) that are not in their predefined list — i.e. the plugin generated tags even though set not to.
2. **Monster tags** that are clearly echoed prompt / reasoning text, e.g.
   `thought-task-analyze-document-content-and-select-up-to-7-relevant-tags-from-a-provided-list-available-tags-cba`.

### Root causes (both in `src/services/baseService.ts`)

1. In **PredefinedTags** mode, the parsed `matchedExistingTags` were trusted as-is and never validated against the candidate list. The prompt instructs the model to pick only from the list, but weak models invent tags or echo the prompt — and those leaked straight through as "matched" tags.
2. The plain-text response fallback (`processTagsFromResponse`) splits on commas with **no length cap**, so when a model returns prose/reasoning instead of a JSON tag list, an entire sentence becomes one tag and then gets kebab-cased into a monster tag.

## Fix

1. After parsing, when mode is `PredefinedTags`, deterministically intersect the matches with the candidate set using a normalized comparison (lowercase, collapse spaces/hyphens/underscores) and return the **canonical candidate spelling**. `suggestedTags` is forced to empty so predefined mode can only ever apply predefined tags. This is the same normalization approach already used for the excluded-tags filter.
2. In the text fallback chokepoint, drop entries longer than 50 chars — well above any real tag, far below echoed sentences — so prose can no longer become a tag in any mode.

## Testing

- `npm run build` passes (tsc + esbuild).
- Logic check: with predefined list `[sailing, ships, history]`, a model returning `crab-claw, lateen, sailing` now yields only `sailing`; echoed-prompt sentences are filtered both by the length cap and (in predefined mode) by the candidate intersection.