### PR TITLE
feat(commands): add folder right-click batch tagging (#62)

### DIFF
--- a/src/commands/generateCommands.ts
+++ b/src/commands/generateCommands.ts
@@ -1,4 +1,4 @@
-import { Editor, MarkdownFileInfo, MarkdownView, Menu, Notice, TFile } from 'obsidian';
+import { Editor, MarkdownFileInfo, MarkdownView, Menu, Notice, TAbstractFile, TFile, TFolder } from 'obsidian';
 import type AITaggerPlugin from '../main';
 import { TagUtils } from '../utils/tagUtils';
 import { TaggingMode } from '../services/prompts/types';
@@ -128,7 +128,7 @@ export function registerGenerateCommands(plugin: AITaggerPlugin) {
     // Register file menu items for batch tagging
     plugin.registerEvent(
         // @ts-ignore - File menu event is not properly typed in Obsidian API
-        plugin.app.workspace.on('file-menu', (menu: Menu, file: TFile, source: string, files?: TFile[]) => {
+        plugin.app.workspace.on('file-menu', (menu: Menu, file: TAbstractFile, source: string, files?: TFile[]) => {
             if (files && files.length > 0) {
                 // Multiple files selected
                 const markdownFiles = files.filter(f => f.extension === 'md');
@@ -151,13 +151,35 @@ export function registerGenerateCommands(plugin: AITaggerPlugin) {
                             });
                     });
                 }
-            } else if (file.extension === 'md') {
+            } else if (file instanceof TFile && file.extension === 'md') {
                 // Single file selected
                 menu.addItem((item) => {
                     item
                         .setTitle(plugin.t.commands.aiTagThisNote)
                         .setIcon('tag')
                         .onClick(() => plugin.analyzeAndTagFiles([file]));
+                });
+            } else if (file instanceof TFolder) {
+                // Folder right-clicked — batch tag all markdown notes inside it (issue #62)
+                menu.addItem((item) => {
+                    item
+                        .setTitle(plugin.t.commands.aiTagThisFolder)
+                        .setIcon('tag')
+                        .onClick(async () => {
+                            const filesInFolder = plugin.getNonExcludedMarkdownFilesFromFolder(file);
+                            if (filesInFolder.length === 0) {
+                                new Notice(plugin.t.messages.noMdFiles);
+                                return;
+                            }
+                            const confirmed = await plugin.showConfirmationDialog(
+                                `${plugin.t.messages.generateTagsForFolderConfirm.replace('{count}', String(filesInFolder.length))}`
+                            );
+                            if (!confirmed) {
+                                new Notice(plugin.t.messages.operationCancelled);
+                                return;
+                            }
+                            await plugin.analyzeAndTagFiles(filesInFolder);
+                        });
                 });
             }
         })

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -117,6 +117,7 @@ export const en: Translations = {
         showTagNetwork: "Show tag network",
         aiTagSelectedNotes: "AI Tag Selected Notes",
         aiTagThisNote: "AI Tag This Note",
+        aiTagThisFolder: "AI Tag Notes in This Folder",
         flattenTagsForCurrentNote: "Flatten hierarchical tags for current note",
         flattenTagsForCurrentFolder: "Flatten hierarchical tags for current folder",
         flattenTagsForVault: "Flatten hierarchical tags for vault",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -115,6 +115,7 @@ export interface Translations {
         showTagNetwork: string;
         aiTagSelectedNotes: string;
         aiTagThisNote: string;
+        aiTagThisFolder: string;
         flattenTagsForCurrentNote: string;
         flattenTagsForCurrentFolder: string;
         flattenTagsForVault: string;

--- a/src/i18n/zh-cn.ts
+++ b/src/i18n/zh-cn.ts
@@ -117,6 +117,7 @@ export const zhCN: Translations = {
         showTagNetwork: "显示标签网络",
         aiTagSelectedNotes: "AI 标记选中的笔记",
         aiTagThisNote: "AI 标记这篇笔记",
+        aiTagThisFolder: "AI 标记此文件夹中的笔记",
         flattenTagsForCurrentNote: "展开当前笔记的层级标签",
         flattenTagsForCurrentFolder: "展开当前文件夹的层级标签",
         flattenTagsForVault: "展开整个库的层级标签",


### PR DESCRIPTION
## Problem

Addresses #62.

A user asked how to batch-tag a whole folder and couldn't find any entry on the folder itself. The `file-menu` handler only added items for markdown files (single + multi-select); right-clicking a **folder** showed nothing. The only folder entry points were the command-palette "Generate tags for current folder" and multi-selecting files.

## Change

Add an **"AI Tag Notes in This Folder"** item to the file context menu when a folder is right-clicked. It:

- collects all non-excluded markdown notes in the folder **recursively** (via the existing `getNonExcludedMarkdownFilesFromFolder`, same as the current-folder command),
- shows the same `generateTagsForFolderConfirm` confirmation dialog with the file count,
- then runs `analyzeAndTagFiles`.

Also widened the `file-menu` callback param to `TAbstractFile` and guarded the existing single-note branch with `file instanceof TFile` so folder and file cases are cleanly distinguished.

New i18n string `commands.aiTagThisFolder` added to `types.ts`, `en.ts` ("AI Tag Notes in This Folder"), and `zh-cn.ts` ("AI 标记此文件夹中的笔记").

## Testing

- `npm run build` passes (tsc + esbuild).
- Manual check still recommended: right-click a folder → confirm the item appears and tags nested notes.