### PR TITLE
chore: add missing version-bump.mjs for npm run version

### DIFF
--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -1,0 +1,21 @@
+import { readFileSync, writeFileSync } from "fs";
+
+// Runs as the `npm version` lifecycle script: npm has already written the new
+// version to package.json and exposes it here. Propagate it to manifest.json
+// and versions.json so all three stay in sync.
+const targetVersion = process.env.npm_package_version;
+if (!targetVersion) {
+    console.error("version-bump: npm_package_version is not set. Run via `npm version <patch|minor|major>`.");
+    process.exit(1);
+}
+
+// Bump manifest.json version, keeping its existing minAppVersion.
+const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
+const { minAppVersion } = manifest;
+manifest.version = targetVersion;
+writeFileSync("manifest.json", JSON.stringify(manifest, null, 2) + "\n");
+
+// Map the new plugin version to the minimum Obsidian version in versions.json.
+const versions = JSON.parse(readFileSync("versions.json", "utf8"));
+versions[targetVersion] = minAppVersion;
+writeFileSync("versions.json", JSON.stringify(versions, null, 2) + "\n");


### PR DESCRIPTION
## Problem

The `version` script in `package.json` is:

```json
"version": "node version-bump.mjs && git add manifest.json versions.json"
```

…but `version-bump.mjs` does not exist in the repo, so `npm run version` (and the `npm version <patch|minor|major>` lifecycle that invokes it) fails. `CLAUDE.md` documents this command as the way to keep `package.json` / `manifest.json` / `versions.json` in sync, so the missing file is a real gap — the 1.0.19 bump had to be done by hand.

## Change

Add the standard Obsidian `version-bump.mjs`, adapted to this repo:

- reads the new version from `process.env.npm_package_version` (set by `npm version`),
- writes it into `manifest.json` (keeping `minAppVersion`),
- adds a `versions.json` entry mapping the new version → `minAppVersion`,
- preserves the repo's **2-space indentation + trailing newline** (so re-bumping doesn't reformat the files),
- exits with a clear error if `npm_package_version` is unset (prevents writing `undefined` as a version).

## Testing

- Run with the current version → **no diff** to `manifest.json`/`versions.json` (idempotent, style matches exactly).
- Run with a throwaway `9.9.9` → correctly bumps manifest and appends the versions entry; reverted.
- Run with no env var → exits 1 with a helpful message.

No production code touched; release artifacts unaffected.